### PR TITLE
Add language selection and multilingual start menu

### DIFF
--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -1,27 +1,26 @@
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
+from bot.localization import t
 
-def main_menu(role: int, channel: str = None, helper: str = None) -> InlineKeyboardMarkup:
+
+def main_menu(role: int, channel: str = None, helper: str = None, lang: str = 'en') -> InlineKeyboardMarkup:
     inline_keyboard = [
+        [InlineKeyboardButton(t(lang, 'shop'), callback_data='shop')],
         [
-            InlineKeyboardButton('🏪 Shop', callback_data='shop'),
-            InlineKeyboardButton('📜 Rules', callback_data='rules'),
-        ],
-        [InlineKeyboardButton('👤 Profile', callback_data='profile')],
+            InlineKeyboardButton(t(lang, 'profile'), callback_data='profile'),
+            InlineKeyboardButton(t(lang, 'top_up'), callback_data='replenish_balance')
+        ]
     ]
-    if helper and channel:
-        inline_keyboard.append([
-            InlineKeyboardButton('🆘 Support', url=f"https://t.me/{helper.lstrip('@')}"),
-            InlineKeyboardButton('ℹ News channel', url=f"https://t.me/{channel}")
-        ])
-    else:
-        if helper:
-            inline_keyboard.append([InlineKeyboardButton('🆘 Support', url=f"https://t.me/{helper.lstrip('@')}")])
-        if channel:
-            inline_keyboard.append(
-                [InlineKeyboardButton('ℹ News channel', url=f"https://t.me/{channel}")])
+    row = []
+    if channel:
+        row.append(InlineKeyboardButton(t(lang, 'channel'), url=f"https://t.me/{channel}"))
+    if helper:
+        row.append(InlineKeyboardButton(t(lang, 'support'), url=f"https://t.me/{helper.lstrip('@')}"))
+    if row:
+        inline_keyboard.append(row)
+    inline_keyboard.append([InlineKeyboardButton(t(lang, 'language'), callback_data='change_language')])
     if role > 1:
-        inline_keyboard.append([InlineKeyboardButton('🎛 Admin panel', callback_data='console')])
+        inline_keyboard.append([InlineKeyboardButton(t(lang, 'admin_panel'), callback_data='console')])
 
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 

--- a/bot/localization.py
+++ b/bot/localization.py
@@ -1,0 +1,49 @@
+LANGUAGES = {
+    'en': {
+        'hello': '👋 Hello, {user}!',
+        'balance': '💰 Balance: {balance} EUR',
+        'basket': '🛒 Basket: {items} item(s)',
+        'overpay': '💳 Send the exact amount. Overpayments will be credited.',
+        'shop': '🛍 Shop',
+        'profile': '👤 Profile',
+        'top_up': '💸 Top Up',
+        'channel': '📢 Channel',
+        'support': '🆘 Support',
+        'language': '🌐 Language',
+        'admin_panel': '🎛 Admin Panel',
+        'choose_language': 'Please choose a language',
+    },
+    'ru': {
+        'hello': '👋 Привет, {user}!',
+        'balance': '💰 Баланс: {balance} EUR',
+        'basket': '🛒 Корзина: {items} шт.',
+        'overpay': '💳 Отправьте точную сумму. Переплаты будут зачислены.',
+        'shop': '🛍 Магазин',
+        'profile': '👤 Профиль',
+        'top_up': '💸 Пополнить',
+        'channel': '📢 Канал',
+        'support': '🆘 Поддержка',
+        'language': '🌐 Язык',
+        'admin_panel': '🎛 Админ панель',
+        'choose_language': 'Пожалуйста, выберите язык',
+    },
+    'lt': {
+        'hello': '👋 Sveiki, {user}!',
+        'balance': '💰 Balansas: {balance} EUR',
+        'basket': '🛒 Krepšelis: {items} prekės',
+        'overpay': '💳 Siųskite tikslią sumą. Permokos bus įskaitytos.',
+        'shop': '🛍 Parduotuvė',
+        'profile': '👤 Profilis',
+        'top_up': '💸 Papildyti',
+        'channel': '📢 Kanalu',
+        'support': '🆘 Pagalba',
+        'language': '🌐 Kalba',
+        'admin_panel': '🎛 Admin pultas',
+        'choose_language': 'Pasirinkite kalbą',
+    },
+}
+
+def t(lang: str, key: str, **kwargs) -> str:
+    lang_data = LANGUAGES.get(lang, LANGUAGES['en'])
+    template = lang_data.get(key, '')
+    return template.format(**kwargs)


### PR DESCRIPTION
## Summary
- add translation dictionary for English, Russian and Lithuanian
- update main menu keyboard to use translations and include language selection
- ask user for preferred language on `/start`
- show start menu text in chosen language
- allow changing language from main menu

## Testing
- `python -m py_compile bot/handlers/user/main.py bot/keyboards/inline.py bot/localization.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859c6b239508320843829d5b0f0ceb0