### PR TITLE
Enable photo delivery for items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ cython_debug/
 .vscode
 .ruff_cache
 database.db
+assets/uploads/

--- a/bot/database/methods/delete.py
+++ b/bot/database/methods/delete.py
@@ -1,19 +1,32 @@
+import os
 from bot.database.models import Database, Goods, ItemValues, Categories, UnfinishedOperations
 
 
 def delete_item(item_name: str) -> None:
+    values = Database().session.query(ItemValues.value).filter(ItemValues.item_name == item_name).all()
+    for val in values:
+        if os.path.isfile(val[0]):
+            os.remove(val[0])
     Database().session.query(Goods).filter(Goods.name == item_name).delete()
     Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).delete()
     Database().session.commit()
 
 
 def delete_only_items(item_name: str) -> None:
+    values = Database().session.query(ItemValues.value).filter(ItemValues.item_name == item_name).all()
+    for val in values:
+        if os.path.isfile(val[0]):
+            os.remove(val[0])
     Database().session.query(ItemValues).filter(ItemValues.item_name == item_name).delete()
 
 
 def delete_category(category_name: str) -> None:
     goods = Database().session.query(Goods.name).filter(Goods.category_name == category_name).all()
     for item in goods:
+        values = Database().session.query(ItemValues.value).filter(ItemValues.item_name == item.name).all()
+        for val in values:
+            if os.path.isfile(val[0]):
+                os.remove(val[0])
         Database().session.query(ItemValues).filter(ItemValues.item_name == item.name).delete()
     Database().session.query(Goods).filter(Goods.category_name == category_name).delete()
     Database().session.query(Categories).filter(Categories.name == category_name).delete()
@@ -27,6 +40,9 @@ def finish_operation(operation_id: str) -> None:
 
 def buy_item(item_id: str, infinity: bool = False) -> None:
     if infinity is False:
+        value = Database().session.query(ItemValues.value).filter(ItemValues.id == item_id).first()
+        if value and os.path.isfile(value[0]):
+            os.remove(value[0])
         Database().session.query(ItemValues).filter(ItemValues.id == item_id).delete()
         Database().session.commit()
     else:

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -363,7 +363,13 @@ async def adding_item(message: Message):
     category_name = TgConfig.STATE.get(f'{user_id}_category')
     answer = TgConfig.STATE.get(f'{user_id}_answer')
     if answer == 'no':
-        values_list = message.text.split(';')
+        if message.photo:
+            file_name = f"{item_name}_{int(datetime.datetime.now().timestamp())}.jpg"
+            file_path = os.path.join('assets', 'uploads', file_name)
+            await message.photo[-1].download(destination_file=file_path)
+            values_list = [file_path]
+        else:
+            values_list = message.text.split(';')
         await bot.delete_message(chat_id=message.chat.id,
                                  message_id=message.message_id)
         create_item(item_name, item_description, item_price, category_name)
@@ -387,7 +393,13 @@ async def adding_item(message: Message):
         logger.info(f"User {user_id} ({admin_info.first_name}) "
                     f'created new item "{item_name}"')
     else:
-        value = message.text
+        if message.photo:
+            file_name = f"{item_name}_{int(datetime.datetime.now().timestamp())}.jpg"
+            file_path = os.path.join('assets', 'uploads', file_name)
+            await message.photo[-1].download(destination_file=file_path)
+            value = file_path
+        else:
+            value = message.text
         await bot.delete_message(chat_id=message.chat.id,
                                  message_id=message.message_id)
         create_item(item_name, item_description, item_price, category_name)
@@ -454,7 +466,13 @@ async def check_item_name_for_amount_upd(message: Message):
 
 async def updating_item_amount(message: Message):
     bot, user_id = await get_bot_user_ids(message)
-    values_list = message.text.split(';')
+    if message.photo:
+        file_name = f"{TgConfig.STATE.get(f'{user_id}_name')}_{int(datetime.datetime.now().timestamp())}.jpg"
+        file_path = os.path.join('assets', 'uploads', file_name)
+        await message.photo[-1].download(destination_file=file_path)
+        values_list = [file_path]
+    else:
+        values_list = message.text.split(';')
     TgConfig.STATE[user_id] = None
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
     item_name = TgConfig.STATE.get(f'{user_id}_name')
@@ -606,7 +624,13 @@ async def update_item_process(call: CallbackQuery):
 
 async def update_item_infinity(message: Message):
     bot, user_id = await get_bot_user_ids(message)
-    msg = message.text
+    if message.photo:
+        file_name = f"{TgConfig.STATE.get(f'{user_id}_old_name')}_{int(datetime.datetime.now().timestamp())}.jpg"
+        file_path = os.path.join('assets', 'uploads', file_name)
+        await message.photo[-1].download(destination_file=file_path)
+        msg = file_path
+    else:
+        msg = message.text
     change = TgConfig.STATE[f'{user_id}_change']
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
     item_old_name = TgConfig.STATE.get(f'{user_id}_old_name')


### PR DESCRIPTION
## Summary
- ignore uploaded item images
- support uploading photos when adding or updating item values
- send a photo when a purchased item value points to an image
- clean up stored images when deleting items or after purchase

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6859dc956c888320b0518ab5c51e24c0